### PR TITLE
fix: ignore contributor statement for dependabot PRs

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -11,6 +11,7 @@ on:
 permissions: read-all
 jobs:
   contributorStatement:
+    if: ${{ ! (github.event.pull_request.user.login == 'amazon-auto' || github.event.pull_request.user.login =='dependabot[bot]') }}
     name: Require Contributor Statement
     runs-on: ubuntu-latest
     permissions:
@@ -20,7 +21,7 @@ jobs:
       EXPECTED: By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
       HELP: Contributor statement missing from PR description. Please include the following text in the PR description
     steps:
-      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |-
             const actual = process.env.PR_BODY.replace(/\r?\n/g, "\n");


### PR DESCRIPTION
Do not require a contributor statement for `dependabot[bot]`

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
