### PR TITLE
fix: action group

### DIFF
--- a/samples/bedrock-agent/lambda/action-group.yaml
+++ b/samples/bedrock-agent/lambda/action-group.yaml
@@ -3,14 +3,14 @@ info:
   title: Literary API
   description: Actions that Bedrock Agents can take to retrieve book details.
   version: 1.0.0
-security:  #checkov:skip=CKV_OPENAPI_4:Sample has no global security field rules
+#checkov:skip=CKV_OPENAPI_4:Sample has no global security field rules
 paths:
   /top_books:
     get:
       summary: Get metadata about the most popular books
       description: Get metadata about the most popular books in the library.
       operationId: getTopBooks
-      security:  #checkov:skip=CKV_OPENAPI_5:Demonstration security operations empty
+      #checkov:skip=CKV_OPENAPI_5:Demonstration security operations empty
       responses:
         '200':
           description: Successful operation


### PR DESCRIPTION
Bedrock doesn't understand the `security` attribute in the OpenAPI 3.0.3 schema so excluding those.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.
